### PR TITLE
Add Windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
     "dev": "cd example && node --require ts-node/register ../src/bin/mdx-site.tsx",
     "prerelease": "yarn build",
     "release": "np",
-    "postbuild": "chmod +x $npm_package_bin_mdx_site"
+    "postbuild": "sh -c 'chmod +x ${npm_package_bin_mdx_site:-dist/bin/mdx-site.js}'"
   },
   "devDependencies": {
     "@types/finalhandler": "^1.1.0",
     "@types/fs-extra": "^8.0.0",
     "@types/html-minifier": "^3.5.3",
     "@types/micro": "^7.3.3",
-    "@types/microrouter": "^3.1.0",
+    "@types/microrouter": "^3.1.1",
     "@types/node": "^12.6.8",
     "@types/ora": "^3.2.0",
     "@types/webpack-env": "^1.14.0",
@@ -31,8 +31,8 @@
   },
   "dependencies": {
     "@mdx-js/runtime": "^1.1.0",
-    "@types/react": "^16.8.23",
-    "@types/react-dom": "^16.8.5",
+    "@types/react": "^16.9.23",
+    "@types/react-dom": "^16.9.5",
     "escape-string-regexp": "^2.0.0",
     "front-matter": "^3.0.2",
     "fs-extra": "^8.1.0",

--- a/src/utils/defaults.tsx
+++ b/src/utils/defaults.tsx
@@ -1,20 +1,23 @@
 import path from "path";
 import React from "react";
 
-const cwd = process.cwd();
-const root = path.resolve(__dirname, "../../");
+const cwd = process.cwd().replace(/\\/g, "/");
+const resolve = path.posix.resolve;
+
+const root = resolve(__dirname, "../../");
+const join = path.posix.join;
 
 export const DefaultLayout = (props: any) => <React.Fragment {...props} />;
 
-export const defaultComponentsDir = path.join(cwd, "components");
-export const defaultContentDir = path.join(cwd, "content");
-export const defaultOutputDir = path.join(cwd, "dist");
-export const defaultPublicDir = path.join(cwd, "public");
+export const defaultComponentsDir = join(cwd, "components");
+export const defaultContentDir = join(cwd, "content");
+export const defaultOutputDir = join(cwd, "dist");
+export const defaultPublicDir = join(cwd, "public");
 
-export const templateDir = path.resolve(root, "template");
-export const templateComponentsDir = path.resolve(templateDir, "components");
-export const templateContentDir = path.resolve(templateDir, "content");
-export const templatePublicDir = path.resolve(templateDir, "public");
+export const templateDir = resolve(root, "template");
+export const templateComponentsDir = resolve(templateDir, "components");
+export const templateContentDir = resolve(templateDir, "content");
+export const templatePublicDir = resolve(templateDir, "public");
 
 // TODO How to configure title? `react-helmet`?
 export const defaultTitle = "Eric Clemmons";

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,10 +271,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/microrouter@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@types/microrouter/-/microrouter-3.1.0.tgz#f24476e153f8ebf680144a5abc9b618207e43827"
-  integrity sha512-uNXXdtwIMbwgaOeQWS7CE0gAaYW9csoQ1k7T/Ak+x+4nApua5Mbex5a97fDR3EGB5O4AJ0d4Febo5L94M23A1g==
+"@types/microrouter@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/microrouter/-/microrouter-3.1.1.tgz#3f5af5572657dbfe57933515675d1057a255e661"
+  integrity sha512-9sWlbNyheqMZNZlRqA4bE051iiZPDSHVtCBT402TIu99/Hs6BtoBMI/8S1OGRXKT6VjCoRRj+Wdb4B+iMgtk8g==
   dependencies:
     "@types/micro" "*"
     "@types/node" "*"
@@ -306,17 +306,25 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
   integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
 
-"@types/react-dom@^16.8.5":
-  version "16.8.5"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.5.tgz#3e3f4d99199391a7fb40aa3a155c8dd99b899cbd"
-  integrity sha512-idCEjROZ2cqh29+trmTmZhsBAUNQuYrF92JHKzZ5+aiFM1mlSk3bb23CK7HhYuOY75Apgap5y2jTyHzaM2AJGA==
+"@types/react-dom@^16.9.5":
+  version "16.9.5"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.5.tgz#5de610b04a35d07ffd8f44edad93a71032d9aaa7"
+  integrity sha512-BX6RQ8s9D+2/gDhxrj8OW+YD4R+8hj7FEM/OJHGNR0KipE1h1mSsf39YeyC81qafkq+N3rU3h3RFbLSwE5VqUg==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.8.23":
+"@types/react@*":
   version "16.8.23"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.23.tgz#ec6be3ceed6353a20948169b6cb4c97b65b97ad2"
   integrity sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/react@^16.9.23":
+  version "16.9.23"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.23.tgz#1a66c6d468ba11a8943ad958a8cb3e737568271c"
+  integrity sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"


### PR DESCRIPTION
Currently mdx-site doesn't work at all on Windows.

I tweaked package.json and the defaults to make things work. 

I also added a default `npm_package_bin_mdx_site` path (which must be set in your environment?), and I bumped a few versions of packages that were causing problems on my system (possibly because I have the latest TypeScript? possibly because Windows? Don't know).

This is likely to be my only contribution because I ran into a wall: I can't import `mdx` or `md` files into other `mdx` files, or at least I haven't been able to figure out how to. This is a showstopper, and I am going to jump to another solution (Next.js is my current plan) that does less work for me, but that is more flexible. But since I'd done the work I thought I'd throw it over the wall in case it's useful to you or others.